### PR TITLE
use customize-set-variable to leverage customize framework

### DIFF
--- a/nano-minibuffer.el
+++ b/nano-minibuffer.el
@@ -159,7 +159,7 @@
   (setq mini-frame-internal-border-color (face-foreground 'nano-faded))
   (setq mini-frame-resize-min-height 3)
   
-  (customize-set-variable mini-frame-resize t)
+  (customize-set-variable 'mini-frame-resize t)
 
   (add-hook 'minibuffer-setup-hook #'nano-minibuffer-setup)
   (mini-frame-mode 1))

--- a/nano-minibuffer.el
+++ b/nano-minibuffer.el
@@ -159,8 +159,7 @@
   (setq mini-frame-internal-border-color (face-foreground 'nano-faded))
   (setq mini-frame-resize-min-height 3)
   
-  ;; This does not work unless it is set via customize-variable
-  (setq mini-frame-resize t)
+  (customize-set-variable mini-frame-resize t)
 
   (add-hook 'minibuffer-setup-hook #'nano-minibuffer-setup)
   (mini-frame-mode 1))


### PR DESCRIPTION
`mini-frame-resize` needs to be set via the customize framework, so `setq` is not the right tool for the job. Use `customize-set-variable` instead.